### PR TITLE
Handle missing data in RequestDevice

### DIFF
--- a/lib/models/RequestDevice.js
+++ b/lib/models/RequestDevice.js
@@ -1,6 +1,7 @@
 var errors = require('../errors');
 
 function RequestDevice(data) {
+    data = data || {};
     this._device = data.Device || null;
 
     if(this._device === null) {

--- a/tests/unit/requestDevice.tests.js
+++ b/tests/unit/requestDevice.tests.js
@@ -1,0 +1,13 @@
+var expect = require('chai').expect;
+
+var RequestDevice = require('../../lib/models/RequestDevice');
+var errors = require('../../lib/errors');
+
+describe('RequestDevice', function() {
+    it('should throw on missing device', function() {
+        expect(function() {
+            new RequestDevice();
+        }).to.throw(errors.BadRequestError);
+    });
+});
+


### PR DESCRIPTION
## Summary
- guard RequestDevice constructor against missing data
- add unit test to ensure BadRequestError is thrown when no arguments provided

## Testing
- `npm test` *(fails: No test files found)*
- `./node_modules/mocha/bin/mocha tests/unit/requestDevice.tests.js`
- `./node_modules/mocha/bin/mocha tests/unit/*.tests.js` *(fails: 2 failing tests in stuff.tests.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a715980aa88323bf321fe0a287f453