### PR TITLE
Validate EnableLocationHistory input types

### DIFF
--- a/lib/models/RequestConfig.js
+++ b/lib/models/RequestConfig.js
@@ -7,10 +7,14 @@ function RequestConfig(data) {
     this._locationDataRetentionTime = data.LocationDataRetentionTime || null;
 
     if(this._enableLocationHistory !== null) {
-        if(this._enableLocationHistory.toLowerCase() === 'true') {
-            this._enableLocationHistory = true;
+        if(typeof this._enableLocationHistory === 'string') {
+            if(this._enableLocationHistory.toLowerCase() === 'true') {
+                this._enableLocationHistory = true;
+            } else {
+                this._enableLocationHistory = false;
+            }
         } else {
-            this._enableLocationHistory = false;
+            this._enableLocationHistory = null;
         }
     }
 

--- a/tests/unit/dataHolder.tests.js
+++ b/tests/unit/dataHolder.tests.js
@@ -8,6 +8,24 @@ describe('dataHolders', function() {
         it('should throw because of invalid data', function() {
             expect(function() { new RequestConfig() }).to.throw();
         });
+
+        it('should throw when EnableLocationHistory is numeric', function() {
+            expect(function() {
+                new RequestConfig({
+                    EnableLocationHistory: 1,
+                    LocationDataRetentionTime: '15'
+                });
+            }).to.throw();
+        });
+
+        it('should throw when EnableLocationHistory is boolean', function() {
+            expect(function() {
+                new RequestConfig({
+                    EnableLocationHistory: true,
+                    LocationDataRetentionTime: '15'
+                });
+            }).to.throw();
+        });
     });
 
     describe('location', function() {


### PR DESCRIPTION
## Summary
- guard EnableLocationHistory against non-string inputs
- add tests for numeric and boolean EnableLocationHistory values

## Testing
- `NODE_ENV=test ./node_modules/mocha/bin/mocha tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68a7159963948323ba3e97731dc655b7