### PR TITLE
Validate RequestLocation property presence

### DIFF
--- a/lib/models/RequestLocation.js
+++ b/lib/models/RequestLocation.js
@@ -3,11 +3,11 @@ var errors = require('../errors');
 function RequestLocation(data) {
     data = data || {};
 
-    this._device = data.Device || false;
-    this._timestamp = data.Timestamp || false;
-    this._longitude = data.Longitude || false;
-    this._latitude = data.Latitude || false;
-    this._horizontalAccuracy = data.HorizontalAccuracy || false;
+    this._device = data.Device || null;
+    this._timestamp = data.Timestamp || null;
+    this._longitude = data.Longitude || null;
+    this._latitude = data.Latitude || null;
+    this._horizontalAccuracy = data.HorizontalAccuracy || null;
 
     this._validate();
 }
@@ -45,7 +45,7 @@ RequestLocation.prototype.data = function() {
 RequestLocation.prototype._validate = function() {
     var that = this;
     Object.keys(this).forEach(function(property) {
-        if(that[property] === null) {
+        if(that[property] === null || that[property] === false) {
             throw new errors.BadRequestError('Missing RequestProperty ' + property + ' in location');
         }
     });

--- a/tests/requestLocation.tests.js
+++ b/tests/requestLocation.tests.js
@@ -1,0 +1,29 @@
+var expect = require('chai').expect;
+
+var RequestLocation = require('../lib/models/RequestLocation');
+var errors = require('../lib/errors');
+
+describe('RequestLocation', function() {
+
+    var validData;
+
+    beforeEach(function() {
+        validData = {
+            Device: 'device',
+            Timestamp: 123456789,
+            Longitude: 1.23,
+            Latitude: 4.56,
+            HorizontalAccuracy: 10
+        };
+    });
+
+    ['Device', 'Timestamp', 'Longitude', 'Latitude', 'HorizontalAccuracy'].forEach(function(prop) {
+        it('should throw BadRequestError when ' + prop + ' is missing', function() {
+            var data = Object.assign({}, validData);
+            delete data[prop];
+            expect(function() { new RequestLocation(data); }).to.throw(errors.BadRequestError);
+        });
+    });
+
+});
+


### PR DESCRIPTION
## Summary
- Initialize RequestLocation model fields with `null` defaults and treat `null` or `false` as missing.
- Add unit tests to ensure missing RequestLocation fields trigger `BadRequestError`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7159e18ac83238a4e4148a95b98b9