### PR TITLE
Handle missing device data in location lookups

### DIFF
--- a/lib/routes/location/v1/location.js
+++ b/lib/routes/location/v1/location.js
@@ -167,29 +167,28 @@ function getLocation(req, res, next) {
             db.get(kb.build(device.device(), KEY_LAST), function (error, reply) {
                 if(error)  return done(error);
 
-                // only if this device is existing we update the visitor list...
-                if (reply != null)
-                {
-                  // store the visitor for this device (if it's not empty)...
-                  var visitKey = kb.build(device.device(), KEY_VISIT);
-                  var miataruVisitorObject = requestConfig.requestMiataruVisitorObject();
-                  // only if the object is not null (= we do not want to store the visitor history of unknown devices)
-                  if (miataruVisitorObject != null)
-                  {
-                      var visitValue = JSON.stringify(miataruVisitorObject);
+                if (reply) {
+                    // only if this device is existing we update the visitor list...
+                    var visitKey = kb.build(device.device(), KEY_VISIT);
+                    var miataruVisitorObject = requestConfig.requestMiataruVisitorObject();
+                    // only if the object is not null (= we do not want to store the visitor history of unknown devices)
+                    if (miataruVisitorObject != null) {
+                        var visitValue = JSON.stringify(miataruVisitorObject);
 
-                      seq()
-                          // we do want to store visitor history, so check if we got, so lpush and trim
-                          .seq(function() {
-                              db.lpush(visitKey, visitValue, this);
-                          })
-                          // take care that the visitor history does not grow beyond the set range of maximumNumberOfLocationVistors
-                          .seq(function() {
-                              db.ltrim(visitKey, 0, configuration.maximumNumberOfLocationVistors-1, this);
-                          });
-                  }
+                        seq()
+                            // we do want to store visitor history, so check if we got, so lpush and trim
+                            .seq(function() {
+                                db.lpush(visitKey, visitValue, this);
+                            })
+                            // take care that the visitor history does not grow beyond the set range of maximumNumberOfLocationVistors
+                            .seq(function() {
+                                db.ltrim(visitKey, 0, configuration.maximumNumberOfLocationVistors-1, this);
+                            });
+                    }
+
+                    response.pushLocation(JSON.parse(reply));
                 }
-                response.pushLocation(JSON.parse(reply));
+
                 done();
             });
         });
@@ -220,7 +219,10 @@ function getLocationGeoJSON(req, res, next) {
             db.get(kb.build(device.device(), KEY_LAST), function (error, reply) {
                 if(error)  return done(error);
 
-                response.pushLocation(JSON.parse(reply));
+                if (reply) {
+                    response.pushLocation(JSON.parse(reply));
+                }
+
                 done();
             });
         });
@@ -249,7 +251,10 @@ function getLocationGeoJSONGET(id, res, next) {
         db.get(kb.build(id, KEY_LAST), function (error, reply) {
             if(error)  return done(error);
 
-            response.pushLocation(JSON.parse(reply));
+            if (reply) {
+                response.pushLocation(JSON.parse(reply));
+            }
+
             done();
         });
     })

--- a/tests/integration/unknownDevice.tests.js
+++ b/tests/integration/unknownDevice.tests.js
@@ -1,0 +1,54 @@
+var expect = require('chai').expect;
+var request = require('request');
+
+var config = require('../../lib/configuration');
+var calls = require('../testFiles/calls');
+
+var serverUrl = 'http://localhost:' + config.port;
+
+describe('unknown device id', function() {
+    it('should return empty location array for GetLocation', function(done) {
+        var options = {
+            url: serverUrl + '/v1/GetLocation',
+            method: 'POST',
+            json: calls.getLocationCall('unknown-device')
+        };
+
+        request(options, function (error, response, body) {
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+            expect(body.MiataruLocation).to.be.an('array').that.is.empty;
+            done();
+        });
+    });
+
+    it('should return empty object for GetLocationGeoJSON', function(done) {
+        var options = {
+            url: serverUrl + '/v1/GetLocationGeoJSON',
+            method: 'POST',
+            json: calls.getLocationCall('unknown-device')
+        };
+
+        request(options, function (error, response, body) {
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+            expect(body).to.be.an('object').that.is.empty;
+            done();
+        });
+    });
+
+    it('should return empty object for GetLocationGeoJSONGET', function(done) {
+        var options = {
+            url: serverUrl + '/v1/GetLocationGeoJSON/unknown-device',
+            method: 'GET',
+            json: true
+        };
+
+        request(options, function (error, response, body) {
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+            expect(body).to.be.an('object').that.is.empty;
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Guard location lookup endpoints against missing data by verifying Redis replies before parsing
- Add integration tests for unknown device IDs across GetLocation and GeoJSON endpoints

## Testing
- `NODE_ENV=test ./node_modules/mocha/bin/mocha "tests/**/*.js"`


------
https://chatgpt.com/codex/tasks/task_e_68a715baac308323842e83d50ab92d83