### PR TITLE
Forward errors from GeoJSON routes

### DIFF
--- a/lib/routes/location/index.js
+++ b/lib/routes/location/index.js
@@ -9,8 +9,8 @@ module.exports.install = function(app) {
     app.post('/v1/UpdateLocation', v1.inputParser, v1.updateLocation);
     app.post('/v1/GetLocation', v1.inputParser, v1.getLocation);
     app.post('/v1/GetLocationGeoJSON', v1.inputParser, v1.getLocationGeoJSON);
-    app.get('/v1/GetLocationGeoJSON/:id?',  function(req, res){
-        v1.getLocationGeoJSONGET(req.params.id, res,null);
+    app.get('/v1/GetLocationGeoJSON/:id?',  function(req, res, next){
+        v1.getLocationGeoJSONGET(req.params.id, res, next);
     });
     app.post('/v1/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
     app.post('/v1/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);
@@ -21,8 +21,8 @@ module.exports.install = function(app) {
     app.post('/UpdateLocation', v1.inputParser, v1.updateLocation);
     app.post('/GetLocation', v1.inputParser, v1.getLocation);
     app.post('/GetLocationGeoJSON', v1.inputParser, v1.getLocationGeoJSON);
-    app.get('/GetLocationGeoJSON/:id?',  function(req, res){
-        v1.getLocationGeoJSONGET(req.params.id, res,null);
+    app.get('/GetLocationGeoJSON/:id?',  function(req, res, next){
+        v1.getLocationGeoJSONGET(req.params.id, res, next);
     });
     app.post('/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
     app.post('/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);

--- a/tests/unit/getLocationGeoJSONGET.error.tests.js
+++ b/tests/unit/getLocationGeoJSONGET.error.tests.js
@@ -1,0 +1,56 @@
+var expect = require('chai').expect;
+var request = require('request');
+var express = require('express');
+var locationRoutes = require('../../lib/routes/location');
+var db = require('../../lib/db');
+
+// Helper to create server with patched db.get throwing error
+
+describe('GetLocationGeoJSONGET error handling', function() {
+    var server;
+    var port;
+    var originalGet;
+
+    before(function(done) {
+        var app = express();
+        app.use(express.bodyParser());
+        locationRoutes.install(app);
+
+        // install error handler similar to server.js
+        app.use(function(error, req, res, next) {
+            res.send(error.statusCode || 500, {error: error.message});
+        });
+
+        originalGet = db.get;
+        db.get = function(key, callback) {
+            callback(new Error('fail'));
+        };
+
+        server = app.listen(0, function() {
+            port = server.address().port;
+            done();
+        });
+    });
+
+    after(function(done) {
+        db.get = originalGet;
+        server.close(done);
+    });
+
+    it('should trigger error handler for versioned route', function(done) {
+        request('http://localhost:' + port + '/v1/GetLocationGeoJSON/foo', function(err, res, body) {
+            expect(res.statusCode).to.equal(500);
+            expect(JSON.parse(body).error).to.equal('fail');
+            done();
+        });
+    });
+
+    it('should trigger error handler for unversioned route', function(done) {
+        request('http://localhost:' + port + '/GetLocationGeoJSON/foo', function(err, res, body) {
+            expect(res.statusCode).to.equal(500);
+            expect(JSON.parse(body).error).to.equal('fail');
+            done();
+        });
+    });
+});
+


### PR DESCRIPTION
## Summary
- pass Express `next` into `/GetLocationGeoJSON` handlers so errors propagate
- add unit tests verifying versioned and unversioned GeoJSON routes hit the error handler

## Testing
- `NODE_ENV=test ./node_modules/mocha/bin/mocha tests/unit tests/integration`

------
https://chatgpt.com/codex/tasks/task_e_68a715c26890832386ca10a31d35a448