### PR TITLE
Add dashboard with device API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Check out the repo:
 Install dependencies:  
 `npm install`
 
-Run the tests:  
+Run the tests:
 `make run-all-tests`
 
 Configuration:
@@ -37,6 +37,10 @@ Adjust the configuration in `./lib/config` or add your own
 
 Start Server:
 `node server.js`
+
+### Dashboard
+
+After starting the server, open `http://localhost:8090/dashboard` (or the port configured in your setup) in a web browser. The dashboard displays device locations and recent history on an interactive map.
 
 The server will, in the default configuration, listen on localhost port 8080. To do some test requests on the commandline, do this:
 

--- a/lib/public/dashboard.html
+++ b/lib/public/dashboard.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Miataru Dashboard</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+    <style>
+        #map { height: 100vh; }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+<script src="/dashboard.js"></script>
+</body>
+</html>

--- a/lib/public/dashboard.js
+++ b/lib/public/dashboard.js
@@ -1,0 +1,39 @@
+function init() {
+    var map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    fetch('/api/devices').then(function(resp){ return resp.json(); }).then(function(data){
+        if(!data.devices) return;
+        data.devices.forEach(function(dev){
+            if(!dev.last) return;
+            var lat = parseFloat(dev.last.Latitude);
+            var lon = parseFloat(dev.last.Longitude);
+            if(isNaN(lat) || isNaN(lon)) return;
+            var marker = L.marker([lat, lon]).addTo(map).bindPopup('Device: ' + dev.device);
+
+            // load history for polyline
+            fetch('/v1/GetLocationHistory', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({MiataruGetLocationHistory:{Device: dev.device, Amount: 10}})
+            }).then(function(r){ return r.json(); }).then(function(hist){
+                if(hist.MiataruLocation){
+                    var latlngs = hist.MiataruLocation.map(function(l){
+                        return [parseFloat(l.Latitude), parseFloat(l.Longitude)];
+                    });
+                    if(latlngs.length > 1){
+                        L.polyline(latlngs, {color: 'blue'}).addTo(map);
+                    }
+                }
+            });
+        });
+    });
+}
+
+if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}

--- a/lib/routes/homepage.js
+++ b/lib/routes/homepage.js
@@ -11,4 +11,14 @@ function index(req, res){
 
 module.exports.install = function(app) {
     app.get('/', index);
+
+    // serve dashboard ui
+    app.get('/dashboard', function(req, res) {
+        res.sendfile(require('path').join(__dirname, '../public/dashboard.html'));
+    });
+
+    // simple route to serve dashboard javascript
+    app.get('/dashboard.js', function(req, res) {
+        res.sendfile(require('path').join(__dirname, '../public/dashboard.js'));
+    });
 };

--- a/lib/routes/location/index.js
+++ b/lib/routes/location/index.js
@@ -1,5 +1,8 @@
 var v1 = require('./v1');
 var errors = require('../../errors');
+var db = require('../../db');
+var kb = require('../../utils/keyBuilder');
+var seq = require('seq');
 
 module.exports.install = function(app) {
 
@@ -24,8 +27,43 @@ module.exports.install = function(app) {
     app.get('/GetLocationGeoJSON/:id?',  function(req, res){
         v1.getLocationGeoJSONGET(req.params.id, res,null);
     });
-    app.post('/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
-    app.post('/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);
+  app.post('/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
+  app.post('/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);
+
+  // REST endpoint for dashboard to list devices
+  app.get('/api/devices', function(req, res, next) {
+      var pattern = kb.build('*', 'last');
+      db.keys(pattern, function(err, keys) {
+          if (err) return next(new errors.InternalServerError(err));
+
+          var devices = [];
+          var chain = seq();
+
+          keys.forEach(function(key) {
+              chain.par(function() {
+                  var done = this;
+                  db.get(key, function(error, data) {
+                      if (error) return done(error);
+                      var id = key.split(':')[1];
+                      var last;
+                      try {
+                          last = JSON.parse(data);
+                      } catch (e) {
+                          last = null;
+                      }
+                      devices.push({device: id, last: last});
+                      done();
+                  });
+              });
+          });
+
+          chain.seq(function() {
+              res.send({devices: devices});
+          }).catch(function(error) {
+              next(new errors.InternalServerError(error));
+          });
+      });
+  });
 
     ///////////////////////////////////////////
     ///// non-Post /////////////////////////
@@ -37,6 +75,7 @@ module.exports.install = function(app) {
     app.all('/UpdateLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/GetLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/GetLocationGeoJSON', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
-    app.all('/GetLocationHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
-    app.all('/GetVisitorHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
-};
+      app.all('/GetLocationHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
+      app.all('/GetVisitorHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
+      app.all('/api/devices', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
+  };

--- a/tests/integration/dashboard.tests.js
+++ b/tests/integration/dashboard.tests.js
@@ -1,0 +1,15 @@
+var expect = require('chai').expect;
+var request = require('request');
+
+var config = require('../../lib/configuration');
+var serverUrl = 'http://localhost:' + config.port;
+
+describe('dashboard route', function() {
+    it('should respond with html', function(done) {
+        request(serverUrl + '/dashboard', function(error, response, body) {
+            expect(error).to.be.null;
+            expect(response.headers['content-type']).to.match(/text\/html/);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Serve a new dashboard UI at `/dashboard` to visualize device locations
- Provide `/api/devices` endpoint for listing devices and their latest positions
- Document dashboard usage and test that the dashboard route returns HTML

## Testing
- `make run-all-tests`


------
https://chatgpt.com/codex/tasks/task_e_68a7177b15308323b8abc9364c89a6f9