### PR TITLE
Add CORS middleware configurable via config

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -38,6 +38,11 @@ module.exports = {
     addEmptyVisitorDeviceIDtoVisitorHistory: false,
 
     //namespacing for redis keys
-    redisMiataruNamespace: "miad"
+    redisMiataruNamespace: "miad",
+
+    //cors configuration
+    cors: {
+        allowedOrigins: ['http://example.com']
+    }
 
 };

--- a/config/test.js
+++ b/config/test.js
@@ -19,5 +19,10 @@ module.exports = {
     addEmptyVisitorDeviceIDtoVisitorHistory: true,
 
     //namespacing for redis keys
-    redisMiataruNamespace: 'miadTest'
+    redisMiataruNamespace: 'miadTest',
+
+    //cors configuration
+    cors: {
+        allowedOrigins: ['http://example.com']
+    }
 };

--- a/lib/middlewares/cors.js
+++ b/lib/middlewares/cors.js
@@ -1,0 +1,16 @@
+var cors = require('cors');
+var config = require('../configuration');
+
+var allowed = (config.cors && config.cors.allowedOrigins) || [];
+
+var options = {
+    origin: function(origin, callback) {
+        if (!origin) return callback(null, true);
+        if (allowed.indexOf('*') !== -1 || allowed.indexOf(origin) !== -1) {
+            return callback(null, true);
+        }
+        return callback(null, false);
+    }
+};
+
+module.exports = cors(options);

--- a/lib/middlewares/index.js
+++ b/lib/middlewares/index.js
@@ -1,4 +1,8 @@
+var cors = require('./cors');
+
 function install(app) {
+    app.use(cors);
+
     //we surely will add some middlewares sometimes...
 
 //    app.use(function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "require-directory": "~1.1.0",
     "moment": ">=2.29.2",
     "optimist": "~0.6.0",
-    "fakeredis": "*"
+    "fakeredis": "*",
+    "cors": "~2.8.5"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/tests/integration/cors.tests.js
+++ b/tests/integration/cors.tests.js
@@ -1,0 +1,38 @@
+var expect = require('chai').expect;
+var request = require('request');
+
+var config = require('../../lib/configuration');
+
+var serverUrl = 'http://localhost:' + config.port;
+
+describe('cors', function() {
+    it('should include CORS headers for allowed origin', function(done) {
+        var options = {
+            url: serverUrl + '/',
+            headers: {
+                Origin: 'http://example.com'
+            }
+        };
+
+        request(options, function(error, response, body) {
+            expect(error).to.be.null;
+            expect(response.headers['access-control-allow-origin']).to.equal('http://example.com');
+            done();
+        });
+    });
+
+    it('should not include CORS headers for disallowed origin', function(done) {
+        var options = {
+            url: serverUrl + '/',
+            headers: {
+                Origin: 'http://notallowed.com'
+            }
+        };
+
+        request(options, function(error, response, body) {
+            expect(error).to.be.null;
+            expect(response.headers['access-control-allow-origin']).to.be.undefined;
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- integrate cors middleware configured by allowedOrigins
- expose allowedOrigins setting in default and test configs
- test middleware behaviour for allowed and disallowed origins

## Testing
- `npm install cors@~2.8.5` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `NODE_ENV=test ./node_modules/mocha/bin/mocha --recursive tests/integration` *(fails: Cannot find module 'cors')*


------
https://chatgpt.com/codex/tasks/task_e_68a717acce2c8323bdfbe28d3301c610