### PR TITLE
Add Redis-backed rate limiting middleware

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -38,6 +38,14 @@ module.exports = {
     addEmptyVisitorDeviceIDtoVisitorHistory: false,
 
     //namespacing for redis keys
-    redisMiataruNamespace: "miad"
+    redisMiataruNamespace: "miad",
+
+    // rate limiting configuration
+    rateLimit: {
+        // time window in seconds for request counting
+        windowSeconds: 60,
+        // maximum number of requests allowed within the time window
+        maxRequests: 100
+    }
 
 };

--- a/config/test.js
+++ b/config/test.js
@@ -19,5 +19,11 @@ module.exports = {
     addEmptyVisitorDeviceIDtoVisitorHistory: true,
 
     //namespacing for redis keys
-    redisMiataruNamespace: 'miadTest'
+    redisMiataruNamespace: 'miadTest',
+
+    // rate limiting configuration
+    rateLimit: {
+        windowSeconds: 60,
+        maxRequests: 100
+    }
 };

--- a/lib/middlewares/index.js
+++ b/lib/middlewares/index.js
@@ -1,10 +1,8 @@
-function install(app) {
-    //we surely will add some middlewares sometimes...
+var rateLimit = require('./rateLimit');
 
-//    app.use(function(req, res, next) {
-//        console.log( 'yay, Im a middleware!' );
-//        next();
-//    });
+function install(app) {
+    //global rate limiting middleware
+    app.use(rateLimit);
 }
 
 module.exports.install = install;

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -1,0 +1,29 @@
+var db = require('../db');
+var configuration = require('../configuration');
+
+var windowSeconds = (configuration.rateLimit && configuration.rateLimit.windowSeconds) || 60;
+var maxRequests = (configuration.rateLimit && configuration.rateLimit.maxRequests) || 100;
+
+module.exports = function(req, res, next) {
+    var ip = req.headers['x-forwarded-for'] ||
+        (req.connection && req.connection.remoteAddress) ||
+        req.ip || 'unknown';
+
+    var key = 'ratelimit:' + ip;
+
+    db.incr(key, function(err, count) {
+        if (err) {
+            return next(err);
+        }
+
+        if (count === 1) {
+            db.expire(key, windowSeconds);
+        }
+
+        if (count > maxRequests) {
+            res.send(429, {error: 'Too many requests'});
+        } else {
+            next();
+        }
+    });
+};

--- a/tests/integration/rateLimit.tests.js
+++ b/tests/integration/rateLimit.tests.js
@@ -1,0 +1,36 @@
+var expect = require('chai').expect;
+var request = require('request');
+
+var config = require('../../lib/configuration');
+
+var serverUrl = 'http://localhost:' + config.port;
+
+describe('rate limit middleware', function() {
+    it('should return 429 after exceeding request threshold', function(done) {
+        this.timeout(10000);
+        var max = config.rateLimit.maxRequests;
+        var ip = '123.4.5.6';
+
+        var options = {
+            url: serverUrl + '/',
+            headers: { 'X-Forwarded-For': ip }
+        };
+
+        function send(n, cb) {
+            request.get(options, function(err, res) {
+                if (err) return cb(err);
+                if (n > 0) {
+                    send(n - 1, cb);
+                } else {
+                    cb(null, res.statusCode);
+                }
+            });
+        }
+
+        send(max, function(err, status) {
+            expect(err).to.be.null;
+            expect(status).to.equal(429);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- enforce request rate limits using Redis counters
- expose rate limit settings in config
- test rate limiting behavior across API routes

## Testing
- `NODE_ENV=test make run-all-tests`

------
https://chatgpt.com/codex/tasks/task_e_68a717cdb31c83238217e3058c08a9f4