### PR TITLE
Add timestamp range support for location history queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ to retrieve a location:
 
 curl -H 'Content-Type: application/json' -X POST 'http://localhost:8080/GetLocation' -d '{"MiataruGetLocation":[{"Device":"7b8e6e0ee5296db345162dc2ef652c1350761823"}]}'
 
+to retrieve location history (optionally filtered by timestamps):
+
+curl -H 'Content-Type: application/json' -X POST 'http://localhost:8080/GetLocationHistory' -d '{"MiataruGetLocationHistory":{"Device":"7b8e6e0ee5296db345162dc2ef652c1350761823","Amount":"25","StartTimestamp":"1376735651302","EndTimestamp":"1376735651400"}}'
+
+`StartTimestamp` and `EndTimestamp` are optional and limit the returned history range.
+
 ## Docker
 
 You can use the included Dockerfile to build your own docker image for running a miataru server. 

--- a/lib/models/RequestLocationHistory.js
+++ b/lib/models/RequestLocationHistory.js
@@ -6,6 +6,24 @@ function RequestLocationHistory(data) {
     this._device = data.Device || null;
     this._amount = +data.Amount || null;
 
+    if (Object.prototype.hasOwnProperty.call(data, 'StartTimestamp')) {
+        this._startTimestamp = +data.StartTimestamp;
+        if (isNaN(this._startTimestamp)) {
+            this._startTimestamp = null;
+        }
+    } else {
+        this._startTimestamp = null;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'EndTimestamp')) {
+        this._endTimestamp = +data.EndTimestamp;
+        if (isNaN(this._endTimestamp)) {
+            this._endTimestamp = null;
+        }
+    } else {
+        this._endTimestamp = null;
+    }
+
     if(this._device === null || this._amount === null) {
         throw new errors.BadRequestError('missing device or amount');
     }
@@ -17,6 +35,14 @@ RequestLocationHistory.prototype.device = function() {
 
 RequestLocationHistory.prototype.amount = function() {
     return this._amount;
+};
+
+RequestLocationHistory.prototype.startTimestamp = function() {
+    return this._startTimestamp;
+};
+
+RequestLocationHistory.prototype.endTimestamp = function() {
+    return this._endTimestamp;
 };
 
 module.exports = RequestLocationHistory;

--- a/lib/routes/location/v1/location.js
+++ b/lib/routes/location/v1/location.js
@@ -43,7 +43,7 @@ function getLocationHistory(req, res, next) {
             db.llen(key, this);
         })
         .par('list', function() {
-            db.lrange(key, 0, locationRequest.amount()-1, this);
+            db.lrange(key, 0, -1, this);
         })
         .seq(function() {
 
@@ -70,12 +70,33 @@ function getLocationHistory(req, res, next) {
               }
             }
 
+            var startTimestamp = locationRequest.startTimestamp();
+            var endTimestamp = locationRequest.endTimestamp();
+
+            var locations = this.vars.list.map(function(value) {
+                return JSON.parse(value);
+            });
+
+            if(startTimestamp !== null) {
+                locations = locations.filter(function(loc) {
+                    return +loc.Timestamp >= startTimestamp;
+                });
+            }
+
+            if(endTimestamp !== null) {
+                locations = locations.filter(function(loc) {
+                    return +loc.Timestamp <= endTimestamp;
+                });
+            }
+
+            var available = locations.length;
+
+            locations = locations.slice(0, locationRequest.amount());
+
             res.send((new models.ResponseLocationHistory(
-                this.vars.listLength,
+                available,
                 configuration.maximumNumberOfHistoryItems,
-                this.vars.list.map(function(value) {
-                    return JSON.parse(value)
-                })
+                locations
             )).data());
         })
         .catch(function(error) {

--- a/tests/integration/getLocationHistory.tests.js
+++ b/tests/integration/getLocationHistory.tests.js
@@ -1,0 +1,89 @@
+var expect = require('chai').expect;
+var request = require('request');
+
+var config = require('../../lib/configuration');
+var calls = require('../testFiles/calls');
+
+var serverUrl = 'http://localhost:' + config.port;
+
+describe('getLocationHistory range queries', function() {
+
+    it('should return locations within the given start and end timestamps', function(done) {
+        var DEVICE = 'rangeDevice1';
+
+        var updateData = calls.locationUpdateCall({
+            config: calls.config({history: true, retentionTime: 100}),
+            locations: [
+                calls.location({device: DEVICE, timeStamp: 1}),
+                calls.location({device: DEVICE, timeStamp: 2}),
+                calls.location({device: DEVICE, timeStamp: 3}),
+                calls.location({device: DEVICE, timeStamp: 4}),
+                calls.location({device: DEVICE, timeStamp: 5})
+            ]
+        });
+
+        var updateOptions = {
+            url: serverUrl + '/v1/UpdateLocation',
+            method: 'POST',
+            json: updateData
+        };
+
+        request(updateOptions, function(error) {
+            expect(error).to.be.null;
+
+            var getOptions = {
+                url: serverUrl + '/v1/GetLocationHistory',
+                method: 'POST',
+                json: calls.getLocationHistoryCall(DEVICE, 10, 2, 4)
+            };
+
+            request(getOptions, function(err, response, body) {
+                expect(err).to.be.null;
+                expect(response.statusCode).to.equal(200);
+                expect(body.MiataruLocation.length).to.equal(3);
+                var timestamps = body.MiataruLocation.map(function(loc) { return loc.Timestamp; });
+                expect(timestamps).to.deep.equal([4,3,2]);
+                done();
+            });
+        });
+    });
+
+    it('should respect only StartTimestamp when EndTimestamp is omitted', function(done) {
+        var DEVICE = 'rangeDevice2';
+
+        var updateData = calls.locationUpdateCall({
+            config: calls.config({history: true, retentionTime: 100}),
+            locations: [
+                calls.location({device: DEVICE, timeStamp: 1}),
+                calls.location({device: DEVICE, timeStamp: 2}),
+                calls.location({device: DEVICE, timeStamp: 3}),
+                calls.location({device: DEVICE, timeStamp: 4}),
+                calls.location({device: DEVICE, timeStamp: 5})
+            ]
+        });
+
+        var updateOptions = {
+            url: serverUrl + '/v1/UpdateLocation',
+            method: 'POST',
+            json: updateData
+        };
+
+        request(updateOptions, function(error) {
+            expect(error).to.be.null;
+
+            var getOptions = {
+                url: serverUrl + '/v1/GetLocationHistory',
+                method: 'POST',
+                json: calls.getLocationHistoryCall(DEVICE, 10, 3)
+            };
+
+            request(getOptions, function(err, response, body) {
+                expect(err).to.be.null;
+                expect(response.statusCode).to.equal(200);
+                var timestamps = body.MiataruLocation.map(function(loc) { return loc.Timestamp; });
+                expect(timestamps).to.deep.equal([5,4,3]);
+                done();
+            });
+        });
+    });
+});

--- a/tests/testFiles/calls.js
+++ b/tests/testFiles/calls.js
@@ -38,13 +38,23 @@ function getLocation(deviceName) {
     };
 }
 
-function getLocationHistory(device, amount) {
-    return {
-        "MiataruGetLocationHistory": {
-            "Device": device || "7b8e6e0ee5296db345162dc2ef652c1350761823",
-            "Amount": amount || "25"
-        }
+function getLocationHistory(device, amount, startTimestamp, endTimestamp) {
+    var body = {
+        "Device": device || "7b8e6e0ee5296db345162dc2ef652c1350761823",
+        "Amount": amount || "25"
+    };
+
+    if(startTimestamp !== undefined) {
+        body.StartTimestamp = startTimestamp;
     }
+
+    if(endTimestamp !== undefined) {
+        body.EndTimestamp = endTimestamp;
+    }
+
+    return {
+        "MiataruGetLocationHistory": body
+    };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- parse optional StartTimestamp/EndTimestamp in RequestLocationHistory
- filter GetLocationHistory results by provided timestamp range
- document new parameters and test range queries
- ensure timestamp parsing gracefully handles missing or invalid values

## Testing
- `make run-all-tests`


------
https://chatgpt.com/codex/tasks/task_e_68a717bcf840832393020ae9dd446080