### PR TITLE
Add DeleteLocation endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ to retrieve a location:
 
 curl -H 'Content-Type: application/json' -X POST 'http://localhost:8080/GetLocation' -d '{"MiataruGetLocation":[{"Device":"7b8e6e0ee5296db345162dc2ef652c1350761823"}]}'
 
+to delete a location:
+
+curl -H 'Content-Type: application/json' -X POST 'http://localhost:8080/DeleteLocation' -d '{"MiataruDeleteLocation":[{"Device":"7b8e6e0ee5296db345162dc2ef652c1350761823"}]}'
+
 ## Docker
 
 You can use the included Dockerfile to build your own docker image for running a miataru server. 

--- a/lib/routes/location/index.js
+++ b/lib/routes/location/index.js
@@ -14,6 +14,7 @@ module.exports.install = function(app) {
     });
     app.post('/v1/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
     app.post('/v1/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);
+    app.post('/v1/DeleteLocation', v1.inputParser, v1.deleteLocation);
 
     ///////////////////////////////////////////
     ///// API current /////////////////////////
@@ -26,6 +27,7 @@ module.exports.install = function(app) {
     });
     app.post('/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
     app.post('/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);
+    app.post('/DeleteLocation', v1.inputParser, v1.deleteLocation);
 
     ///////////////////////////////////////////
     ///// non-Post /////////////////////////
@@ -34,9 +36,11 @@ module.exports.install = function(app) {
     app.all('/v1/GetLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/v1/GetLocationGeoJSON', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/v1/GetLocationHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
+    app.all('/v1/DeleteLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/UpdateLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/GetLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/GetLocationGeoJSON', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/GetLocationHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
     app.all('/GetVisitorHistory', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
+    app.all('/DeleteLocation', function(req, res, next) { next(new errors.MethodNotSupportedError(req.method, req.path));});
 };

--- a/lib/routes/location/v1/index.js
+++ b/lib/routes/location/v1/index.js
@@ -8,5 +8,6 @@ module.exports = {
     getLocationGeoJSON: location.getLocationGeoJSON,
     getLocationGeoJSONGET: location.getLocationGeoJSONGET,
     getLocationHistory: location.getLocationHistory,
-    getVisitorHistory: location.getVisitorHistory
+    getVisitorHistory: location.getVisitorHistory,
+    deleteLocation: location.deleteLocation
 };

--- a/lib/routes/location/v1/inputParser.js
+++ b/lib/routes/location/v1/inputParser.js
@@ -32,6 +32,10 @@ module.exports = function(req, res, next) {
             case '/GetVisitorHistory':
                 parseGetVisitorHistory(req);
                 break;
+            case '/DeleteLocation':
+            case '/v1/DeleteLocation':
+                parseDeleteLocation(req);
+                break;
         }
     }
     catch(error) {
@@ -86,4 +90,16 @@ function parseGetLocationHistory(req) {
 
 function parseGetVisitorHistory(req) {
     req.MIATARU.request = new RequestVisitorHistory(req.body['MiataruGetVisitorHistory'] || {});
+}
+
+function parseDeleteLocation(req) {
+    var locations = req.body['MiataruDeleteLocation'];
+
+    if(!locations || !Array.isArray(locations)) {
+        locations = [{}];
+    }
+
+    req.MIATARU.devices = locations.map(function(device) {
+        return new RequestDevice(device);
+    });
 }

--- a/lib/routes/location/v1/location.js
+++ b/lib/routes/location/v1/location.js
@@ -292,6 +292,43 @@ function getVisitorHistory(req, res, next) {
         });
 }
 
+/**
+ * DeleteLocation
+ * Removes last known location and history for a given device
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+function deleteLocation(req, res, next) {
+    var devices = req.MIATARU.devices || [];
+
+    var chain = seq();
+
+    devices.forEach(function(device) {
+        chain.par(function() {
+            var done = this;
+            var lastKey = kb.build(device.device(), KEY_LAST);
+            var historyKey = kb.build(device.device(), KEY_HISTORY);
+
+            seq()
+                .par(function() { db.del(lastKey, this); })
+                .par(function() { db.del(historyKey, this); })
+                .seq(function() { done(); })
+                .catch(done);
+        });
+    });
+
+    chain
+        .seq(function() {
+            var eyes = ['x', '!', '^', '°'];
+            res.send((new models.ResponseUpdateLocation(eyes[parseInt(Math.random() * eyes.length, 10)])).data());
+        })
+        .catch(function(error) {
+            next(new errors.InternalServerError(error));
+        });
+}
+
 
 module.exports = {
     updateLocation: updateLocation,
@@ -299,5 +336,6 @@ module.exports = {
     getLocationGeoJSON: getLocationGeoJSON,
     getLocationGeoJSONGET: getLocationGeoJSONGET,
     getLocationHistory: getLocationHistory,
-    getVisitorHistory: getVisitorHistory
+    getVisitorHistory: getVisitorHistory,
+    deleteLocation: deleteLocation
 };

--- a/tests/integration/deleteLocation.tests.js
+++ b/tests/integration/deleteLocation.tests.js
@@ -1,0 +1,69 @@
+var expect = require('chai').expect;
+var request = require('request');
+
+var config = require('../../lib/configuration');
+var calls = require('../testFiles/calls');
+
+var serverUrl = 'http://localhost:' + config.port;
+
+describe('deleteLocation', function() {
+
+    var DEVICE = 'device-to-delete';
+
+    before(function(done) {
+        var updateData = calls.locationUpdateCall({
+            config: calls.config({history: true, retentionTime: 100}),
+            locations: [calls.location({device: DEVICE, timeStamp: 1})]
+        });
+
+        var options = {
+            url: serverUrl + '/v1/UpdateLocation',
+            method: 'POST',
+            json: updateData
+        };
+
+        request(options, function(error, response, body) {
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('should delete location and history and respond with ACK', function(done) {
+        var options = {
+            url: serverUrl + '/v1/DeleteLocation',
+            method: 'POST',
+            json: calls.deleteLocationCall(DEVICE)
+        };
+
+        request(options, function(error, response, body) {
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+            expect(body.MiataruResponse).to.equal('ACK');
+
+            var getLocationOptions = {
+                url: serverUrl + '/v1/GetLocation',
+                method: 'POST',
+                json: calls.getLocationCall(DEVICE)
+            };
+
+            request(getLocationOptions, function(err2, res2, body2) {
+                expect(err2).to.be.null;
+                expect(body2.MiataruLocation[0]).to.be.null;
+
+                var getHistoryOptions = {
+                    url: serverUrl + '/v1/GetLocationHistory',
+                    method: 'POST',
+                    json: calls.getLocationHistoryCall(DEVICE, 10)
+                };
+
+                request(getHistoryOptions, function(err3, res3, body3) {
+                    expect(err3).to.be.null;
+                    expect(body3.MiataruServerConfig.AvailableDeviceLocationUpdates).to.equal(0);
+                    expect(body3.MiataruLocation.length).to.equal(0);
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/tests/testFiles/calls.js
+++ b/tests/testFiles/calls.js
@@ -47,10 +47,21 @@ function getLocationHistory(device, amount) {
     }
 }
 
+function deleteLocation(deviceName) {
+    return {
+        "MiataruDeleteLocation": [
+            {
+                "Device": deviceName || "foo"
+            }
+        ]
+    };
+}
+
 module.exports = {
     getLocationHistoryCall: getLocationHistory,
     getLocationCall: getLocation,
     locationUpdateCall: locationUpdate,
     config: config,
-    location: location
+    location: location,
+    deleteLocationCall: deleteLocation
 };


### PR DESCRIPTION
## Summary
- implement DeleteLocation API handler deleting current and historical data
- expose new DeleteLocation endpoints for v1 and default API
- document and test the DeleteLocation workflow

## Testing
- `make run-all-tests`

------
https://chatgpt.com/codex/tasks/task_e_68a717b91ed083238307809abeb949dc