### PR TITLE
Modernize server for Node 18 and Express 4

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,18 +1,23 @@
-var redis = require('redis');
-var fakeRedis = require('fakeredis');
+const redis = require('redis');
+const fakeRedis = require('fakeredis');
 
-var configuration = require('./configuration');
+const configuration = require('./configuration');
 
-var DB_KEY_MOCK = 'mock';
-var DB_KEY_REAL = 'real';
+const DB_KEY_MOCK = 'mock';
+const DB_KEY_REAL = 'real';
 
-var myRedis;
+let myRedis;
 
-if(configuration.database.type === DB_KEY_MOCK) {
+if (configuration.database.type === DB_KEY_MOCK) {
     myRedis = fakeRedis.createClient();
 } else {
-    //TODO: the options hash needs love, we probably should read some of them from the config
-    myRedis = redis.createClient(configuration.database.port, configuration.database.host, {});
+    myRedis = redis.createClient({
+        url: `redis://${configuration.database.host}:${configuration.database.port}`,
+        legacyMode: true,
+        username: configuration.database.userName || undefined,
+        password: configuration.database.password || undefined,
+    });
+    myRedis.connect().catch(console.error);
 }
 
 module.exports = myRedis;

--- a/package.json
+++ b/package.json
@@ -26,24 +26,26 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "express": "~3.3.5",
-    "redis": "~0.8.4",
-    "ejs": "~2.5.5",
-    "stylus": "~0.37.0",
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2",
+    "serve-favicon": "^2.5.0",
+    "redis": "^4.6.7",
+    "fakeredis": "^2.0.0",
+    "ejs": "^3.1.9",
+    "stylus": "^0.59.0",
     "cloneextend": "0.0.3",
-    "seq": "~0.3.5",
-    "require-directory": "~1.1.0",
-    "moment": ">=2.29.2",
-    "optimist": "~0.6.0",
-    "fakeredis": "*"
+    "seq": "^0.3.5",
+    "require-directory": "^2.1.1",
+    "moment": "^2.29.4",
+    "optimist": "^0.6.1"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 18"
   },
   "devDependencies": {
-    "mocha": "~3.2.0",
-    "chai": "*",
-    "request": "~2.81.0"
+    "mocha": "^10.4.0",
+    "chai": "^4.3.7",
+    "request": "^2.88.2"
   },
   "files": [
     "server.js"
@@ -51,6 +53,6 @@
   "main": "./server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "./node_modules/mocha/bin/mocha tests"
+    "test": "NODE_ENV=test mocha --recursive tests"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,18 +1,21 @@
-var http = require('http');
-var path = require('path');
+const http = require('http');
+const path = require('path');
 
-var express = require('express');
+const express = require('express');
+const bodyParser = require('body-parser');
+const favicon = require('serve-favicon');
 
-var configuration = require('./lib/configuration');
-var routes = require('./lib/routes');
-var middlewares = require('./lib/middlewares');
-var logger = require('./lib/logger');
-var errors = require('./lib/errors');
+const configuration = require('./lib/configuration');
+const routes = require('./lib/routes');
+const middlewares = require('./lib/middlewares');
+const logger = require('./lib/logger');
+const errors = require('./lib/errors');
 
-var app = express();
+const app = express();
 
-app.use(express.bodyParser());
-app.use(express.favicon(__dirname + '/favicon.ico')); 
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(favicon(path.join(__dirname, 'favicon.ico')));
 
 middlewares.install(app);
 routes.install(app);
@@ -25,10 +28,11 @@ app.use(handleError);
 
 app.listen(configuration.port, configuration.listenip);
 
-logger.info('miataru server is listening to: %d on %s', configuration.port,configuration.listenip);
+logger.info('miataru server is listening to: %d on %s', configuration.port, configuration.listenip);
 
 function handleError(error, req, res, next) {
     logger.error('error handler received error: ' + error.message);
 
-    res.send(error.statusCode || 500, {error: error.message});
+    res.status(error.statusCode || 500).send({ error: error.message });
 }
+


### PR DESCRIPTION
## Summary
- update dependencies and dev tooling for current Node
- switch to Express 4 with body-parser and serve-favicon
- refresh Redis client implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75c50de148323aee5dde5dea6d3e2