### PR TITLE
Store speed, battery level and altitude

### DIFF
--- a/lib/models/RequestConfigGetLocation.js
+++ b/lib/models/RequestConfigGetLocation.js
@@ -5,9 +5,9 @@ function RequestConfigGetLocation(data) {
     data = data || {};
 
     this._requestMiataruDeviceID = data.RequestMiataruDeviceID || null;
-    this._speed = data.Speed;
-    this._batteryLevel = data.BatteryLevel;
-    this._altitude = data.Altitude;
+    this._speed = data.Speed !== undefined ? parseFloat(data.Speed) : undefined;
+    this._batteryLevel = data.BatteryLevel !== undefined ? parseFloat(data.BatteryLevel) : undefined;
+    this._altitude = data.Altitude !== undefined ? parseFloat(data.Altitude) : undefined;
 
     if (this._requestMiataruDeviceID === null)
     {

--- a/lib/models/RequestConfigGetLocation.js
+++ b/lib/models/RequestConfigGetLocation.js
@@ -5,6 +5,9 @@ function RequestConfigGetLocation(data) {
     data = data || {};
 
     this._requestMiataruDeviceID = data.RequestMiataruDeviceID || null;
+    this._speed = data.Speed;
+    this._batteryLevel = data.BatteryLevel;
+    this._altitude = data.Altitude;
 
     if (this._requestMiataruDeviceID === null)
     {
@@ -26,6 +29,18 @@ RequestConfigGetLocation.prototype.requestMiataruVisitorObject = function() {
     this._VisitorObject = {};
     this._VisitorObject.DeviceID = this._requestMiataruDeviceID;
     this._VisitorObject.TimeStamp = Date.now();
+
+    if(this._speed !== undefined && this._speed !== null) {
+        this._VisitorObject.Speed = this._speed;
+    }
+
+    if(this._batteryLevel !== undefined && this._batteryLevel !== null) {
+        this._VisitorObject.BatteryLevel = this._batteryLevel;
+    }
+
+    if(this._altitude !== undefined && this._altitude !== null) {
+        this._VisitorObject.Altitude = this._altitude;
+    }
 
     return this._VisitorObject;
 };

--- a/lib/models/RequestLocation.js
+++ b/lib/models/RequestLocation.js
@@ -8,6 +8,9 @@ function RequestLocation(data) {
     this._longitude = data.Longitude || false;
     this._latitude = data.Latitude || false;
     this._horizontalAccuracy = data.HorizontalAccuracy || false;
+    this._speed = data.Speed;
+    this._batteryLevel = data.BatteryLevel;
+    this._altitude = data.Altitude;
 
     this._validate();
 }
@@ -32,14 +35,40 @@ RequestLocation.prototype.horizontalAccuracy = function() {
     return this._horizontalAccuracy;
 };
 
+RequestLocation.prototype.speed = function() {
+    return this._speed;
+};
+
+RequestLocation.prototype.batteryLevel = function() {
+    return this._batteryLevel;
+};
+
+RequestLocation.prototype.altitude = function() {
+    return this._altitude;
+};
+
 RequestLocation.prototype.data = function() {
-    return {
+    var result = {
         Device: this._device,
         Timestamp: this._timestamp,
         Longitude: this._longitude,
         Latitude: this._latitude,
         HorizontalAccuracy: this._horizontalAccuracy
     };
+
+    if(this._speed !== undefined && this._speed !== null) {
+        result.Speed = this._speed;
+    }
+
+    if(this._batteryLevel !== undefined && this._batteryLevel !== null) {
+        result.BatteryLevel = this._batteryLevel;
+    }
+
+    if(this._altitude !== undefined && this._altitude !== null) {
+        result.Altitude = this._altitude;
+    }
+
+    return result;
 };
 
 RequestLocation.prototype._validate = function() {

--- a/lib/models/ResponseLocationGeoJSON.js
+++ b/lib/models/ResponseLocationGeoJSON.js
@@ -9,18 +9,33 @@ ResponseLocationGeoJSON.prototype.pushLocation = function(location) {
 ResponseLocationGeoJSON.prototype.data = function() {
     if (this._locationsList[0] && this._locationsList[0].Latitude && this._locationsList[0].Longitude)
     {
+        var loc = this._locationsList[0];
+        var properties = {
+            name: loc.Device
+        };
+
+        if(loc.Speed !== undefined && loc.Speed !== null) {
+            properties.Speed = loc.Speed;
+        }
+
+        if(loc.BatteryLevel !== undefined && loc.BatteryLevel !== null) {
+            properties.BatteryLevel = loc.BatteryLevel;
+        }
+
+        if(loc.Altitude !== undefined && loc.Altitude !== null) {
+            properties.Altitude = loc.Altitude;
+        }
+
         return {
             geometry: {
                 type: "Point",
-                coordinates: [parseFloat(this._locationsList[0].Longitude),parseFloat(this._locationsList[0].Latitude)]
+                coordinates: [parseFloat(loc.Longitude), parseFloat(loc.Latitude)]
             },
             type: "Feature",
-            properties: {
-                name: this._locationsList[0].Device
-            }
+            properties: properties
         }
     };
-    
+
     return {};
 };
 

--- a/lib/routes/location/index.js
+++ b/lib/routes/location/index.js
@@ -9,8 +9,8 @@ module.exports.install = function(app) {
     app.post('/v1/UpdateLocation', v1.inputParser, v1.updateLocation);
     app.post('/v1/GetLocation', v1.inputParser, v1.getLocation);
     app.post('/v1/GetLocationGeoJSON', v1.inputParser, v1.getLocationGeoJSON);
-    app.get('/v1/GetLocationGeoJSON/:id?',  function(req, res){
-        v1.getLocationGeoJSONGET(req.params.id, res,null);
+    app.get('/v1/GetLocationGeoJSON/:id?',  function(req, res, next){
+        v1.getLocationGeoJSONGET(req, res, next);
     });
     app.post('/v1/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
     app.post('/v1/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);
@@ -21,8 +21,8 @@ module.exports.install = function(app) {
     app.post('/UpdateLocation', v1.inputParser, v1.updateLocation);
     app.post('/GetLocation', v1.inputParser, v1.getLocation);
     app.post('/GetLocationGeoJSON', v1.inputParser, v1.getLocationGeoJSON);
-    app.get('/GetLocationGeoJSON/:id?',  function(req, res){
-        v1.getLocationGeoJSONGET(req.params.id, res,null);
+    app.get('/GetLocationGeoJSON/:id?',  function(req, res, next){
+        v1.getLocationGeoJSONGET(req, res, next);
     });
     app.post('/GetLocationHistory', v1.inputParser, v1.getLocationHistory);
     app.post('/GetVisitorHistory', v1.inputParser, v1.getVisitorHistory);

--- a/lib/routes/location/v1/inputParser.js
+++ b/lib/routes/location/v1/inputParser.js
@@ -74,6 +74,7 @@ function parseGetLocationsGeoJSON(req) {
         locations = [{}];
     }
 
+    req.MIATARU.config = new RequestConfigGetLocation(req.body['MiataruConfig'] || {});
     req.MIATARU.devices = locations.map(function(device) {
         return new RequestDevice(device);
     });

--- a/lib/routes/location/v1/location.js
+++ b/lib/routes/location/v1/location.js
@@ -212,6 +212,7 @@ function getLocation(req, res, next) {
 function getLocationGeoJSON(req, res, next) {
     var chain = seq();
     var response = new models.ResponseLocationGeoJSON();
+    var requestConfig = req.MIATARU.config;
 
     req.MIATARU.devices.forEach(function(device) {
         chain.par(function() {
@@ -220,7 +221,23 @@ function getLocationGeoJSON(req, res, next) {
             db.get(kb.build(device.device(), KEY_LAST), function (error, reply) {
                 if(error)  return done(error);
 
-                response.pushLocation(JSON.parse(reply));
+                if (reply != null) {
+                    var visitKey = kb.build(device.device(), KEY_VISIT);
+                    var miataruVisitorObject = requestConfig.requestMiataruVisitorObject();
+                    if (miataruVisitorObject != null) {
+                        var visitValue = JSON.stringify(miataruVisitorObject);
+
+                        seq()
+                            .seq(function() {
+                                db.lpush(visitKey, visitValue, this);
+                            })
+                            .seq(function() {
+                                db.ltrim(visitKey, 0, configuration.maximumNumberOfLocationVistors-1, this);
+                            });
+                    }
+
+                    response.pushLocation(JSON.parse(reply));
+                }
                 done();
             });
         });

--- a/lib/routes/location/v1/location.js
+++ b/lib/routes/location/v1/location.js
@@ -256,9 +256,11 @@ function getLocationGeoJSON(req, res, next) {
  * @param res
  * @param next
  */
-function getLocationGeoJSONGET(id, res, next) {
+function getLocationGeoJSONGET(req, res, next) {
     var chain = seq();
     var response = new models.ResponseLocationGeoJSON();
+    var requestConfig = new models.RequestConfigGetLocation(req.query || {});
+    var id = req.params.id;
 
     chain.par(function() {
         var done = this;
@@ -266,7 +268,23 @@ function getLocationGeoJSONGET(id, res, next) {
         db.get(kb.build(id, KEY_LAST), function (error, reply) {
             if(error)  return done(error);
 
-            response.pushLocation(JSON.parse(reply));
+            if (reply != null) {
+                var visitKey = kb.build(id, KEY_VISIT);
+                var miataruVisitorObject = requestConfig.requestMiataruVisitorObject();
+                if (miataruVisitorObject != null) {
+                    var visitValue = JSON.stringify(miataruVisitorObject);
+
+                    seq()
+                        .seq(function() {
+                            db.lpush(visitKey, visitValue, this);
+                        })
+                        .seq(function() {
+                            db.ltrim(visitKey, 0, configuration.maximumNumberOfLocationVistors-1, this);
+                        });
+                }
+
+                response.pushLocation(JSON.parse(reply));
+            }
             done();
         });
     })

--- a/tests/integration/api.tests.js
+++ b/tests/integration/api.tests.js
@@ -349,4 +349,43 @@ describe('complete chain', function() {
         });
 
     });
+
+    describe('with additional fields', function() {
+        var result;
+        var DEVICE = 'foo-extra';
+
+        before(function(done) {
+            var data = {
+                updateLocation: calls.locationUpdateCall({
+                    config: calls.config({history: true, retentionTime: 100}),
+                    locations: [
+                        calls.location({device: DEVICE, timeStamp: 1, speed: 12.3, batteryLevel: 45.6, altitude: 789.0})
+                    ]
+                }),
+                getLocation: calls.getLocationCall(DEVICE),
+                getLocationHistory: calls.getLocationHistoryCall(DEVICE, 10)
+            };
+
+            completeChain(data, 'v1', function(error, data) {
+                result = data;
+
+                done();
+            });
+        });
+
+        it('should include speed in responses', function() {
+            expect(result.getLocation.MiataruLocation[0].Speed).to.equal(12.3);
+            expect(result.getLocationHistory.MiataruLocation[0].Speed).to.equal(12.3);
+        });
+
+        it('should include battery level in responses', function() {
+            expect(result.getLocation.MiataruLocation[0].BatteryLevel).to.equal(45.6);
+            expect(result.getLocationHistory.MiataruLocation[0].BatteryLevel).to.equal(45.6);
+        });
+
+        it('should include altitude in responses', function() {
+            expect(result.getLocation.MiataruLocation[0].Altitude).to.equal(789.0);
+            expect(result.getLocationHistory.MiataruLocation[0].Altitude).to.equal(789.0);
+        });
+    });
 });

--- a/tests/integration/api.tests.js
+++ b/tests/integration/api.tests.js
@@ -516,3 +516,67 @@ describe('visitor history with additional fields', function() {
         expect(result.MiataruVisitors[0].DeviceID).to.equal(VISITOR_DEVICE);
     });
 });
+
+describe('visitor history via GeoJSON with additional fields', function() {
+    var result;
+    var DEVICE = 'foo-visited-geojson';
+    var VISITOR_DEVICE = 'foo-visitor-geojson';
+
+    before(function(done) {
+        var updateOptions = {
+            url: serverUrl + '/v1/UpdateLocation',
+            method: 'POST',
+            json: calls.locationUpdateCall({
+                config: calls.config({history: false, retentionTime: 100}),
+                locations: [calls.location({device: DEVICE, timeStamp: 1})]
+            })
+        };
+
+        request(updateOptions, function(err) {
+            if (err) return done(err);
+
+            var getOptions = {
+                url: serverUrl + '/v1/GetLocationGeoJSON',
+                method: 'POST',
+                json: calls.getLocationCall(DEVICE, {
+                    RequestMiataruDeviceID: VISITOR_DEVICE,
+                    Speed: 12.3,
+                    BatteryLevel: 45.6,
+                    Altitude: 789.0
+                })
+            };
+
+            request(getOptions, function(err2) {
+                if (err2) return done(err2);
+
+                var historyOptions = {
+                    url: serverUrl + '/v1/GetVisitorHistory',
+                    method: 'POST',
+                    json: calls.getVisitorHistoryCall(DEVICE, 10)
+                };
+
+                request(historyOptions, function(err3, response3, body3) {
+                    if (err3) return done(err3);
+                    result = body3;
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should include visitor speed in history', function() {
+        expect(result.MiataruVisitors[0].Speed).to.equal(12.3);
+    });
+
+    it('should include visitor battery level in history', function() {
+        expect(result.MiataruVisitors[0].BatteryLevel).to.equal(45.6);
+    });
+
+    it('should include visitor altitude in history', function() {
+        expect(result.MiataruVisitors[0].Altitude).to.equal(789.0);
+    });
+
+    it('should record visitor device id', function() {
+        expect(result.MiataruVisitors[0].DeviceID).to.equal(VISITOR_DEVICE);
+    });
+});

--- a/tests/integration/api.tests.js
+++ b/tests/integration/api.tests.js
@@ -580,3 +580,60 @@ describe('visitor history via GeoJSON with additional fields', function() {
         expect(result.MiataruVisitors[0].DeviceID).to.equal(VISITOR_DEVICE);
     });
 });
+
+describe('visitor history via GeoJSON GET with additional fields', function() {
+    var result;
+    var DEVICE = 'foo-visited-geojson-get';
+    var VISITOR_DEVICE = 'foo-visitor-geojson-get';
+
+    before(function(done) {
+        var updateOptions = {
+            url: serverUrl + '/v1/UpdateLocation',
+            method: 'POST',
+            json: calls.locationUpdateCall({
+                config: calls.config({history: false, retentionTime: 100}),
+                locations: [calls.location({device: DEVICE, timeStamp: 1})]
+            })
+        };
+
+        request(updateOptions, function(err) {
+            if (err) return done(err);
+
+            var getUrl = serverUrl + '/v1/GetLocationGeoJSON/' + DEVICE +
+                '?RequestMiataruDeviceID=' + VISITOR_DEVICE +
+                '&Speed=12.3&BatteryLevel=45.6&Altitude=789.0';
+
+            request({url: getUrl, method: 'GET', json: true}, function(err2) {
+                if (err2) return done(err2);
+
+                var historyOptions = {
+                    url: serverUrl + '/v1/GetVisitorHistory',
+                    method: 'POST',
+                    json: calls.getVisitorHistoryCall(DEVICE, 10)
+                };
+
+                request(historyOptions, function(err3, response3, body3) {
+                    if (err3) return done(err3);
+                    result = body3;
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should include visitor speed in history', function() {
+        expect(result.MiataruVisitors[0].Speed).to.equal(12.3);
+    });
+
+    it('should include visitor battery level in history', function() {
+        expect(result.MiataruVisitors[0].BatteryLevel).to.equal(45.6);
+    });
+
+    it('should include visitor altitude in history', function() {
+        expect(result.MiataruVisitors[0].Altitude).to.equal(789.0);
+    });
+
+    it('should record visitor device id', function() {
+        expect(result.MiataruVisitors[0].DeviceID).to.equal(VISITOR_DEVICE);
+    });
+});

--- a/tests/testFiles/calls.js
+++ b/tests/testFiles/calls.js
@@ -42,14 +42,20 @@ function locationUpdate(options) {
     }
 }
 
-function getLocation(deviceName) {
-    return {
+function getLocation(deviceName, config) {
+    var call = {
         "MiataruGetLocation":[
             {
                 "Device": deviceName || "foo"
             }
         ]
     };
+
+    if(config) {
+        call.MiataruConfig = config;
+    }
+
+    return call;
 }
 
 function getLocationHistory(device, amount) {
@@ -61,9 +67,19 @@ function getLocationHistory(device, amount) {
     }
 }
 
+function getVisitorHistory(device, amount) {
+    return {
+        "MiataruGetVisitorHistory": {
+            "Device": device || "foo",
+            "Amount": amount || "25"
+        }
+    };
+}
+
 module.exports = {
     getLocationHistoryCall: getLocationHistory,
     getLocationCall: getLocation,
+    getVisitorHistoryCall: getVisitorHistory,
     locationUpdateCall: locationUpdate,
     config: config,
     location: location

--- a/tests/testFiles/calls.js
+++ b/tests/testFiles/calls.js
@@ -1,13 +1,27 @@
 function location(options) {
     options = options || {};
 
-    return {
+    var loc = {
         "Device": options.device || "bar",
         "Timestamp": options.timeStamp || "1376735651302",
         "Longitude": options.longitude || "10.837502",
         "Latitude": options.latitude || "49.828925",
         "HorizontalAccuracy": options.accuracy || "50.00"
     };
+
+    if(options.speed !== undefined) {
+        loc.Speed = options.speed;
+    }
+
+    if(options.batteryLevel !== undefined) {
+        loc.BatteryLevel = options.batteryLevel;
+    }
+
+    if(options.altitude !== undefined) {
+        loc.Altitude = options.altitude;
+    }
+
+    return loc;
 }
 
 function config(options) {


### PR DESCRIPTION
## Summary
- persist optional Speed, BatteryLevel and Altitude values when updating locations
- expose these new fields in GetLocation and history responses
- cover new fields in integration tests

## Testing
- `npm install`
- `make run-all-tests`


------
https://chatgpt.com/codex/tasks/task_e_68b82dfec75483238039fd40560ea2d8