### PR TITLE
Add robots.txt route

### DIFF
--- a/lib/routes/homepage.js
+++ b/lib/routes/homepage.js
@@ -9,6 +9,12 @@ function index(req, res){
         'API-Documentation: http://www.miataru.com/#tabr4');
 }
 
+function robots(req, res) {
+    res.type('text/plain');
+    res.send('User-agent: *\nDisallow:');
+}
+
 module.exports.install = function(app) {
     app.get('/', index);
+    app.get('/robots.txt', robots);
 };

--- a/tests/integration/robots.tests.js
+++ b/tests/integration/robots.tests.js
@@ -1,0 +1,44 @@
+var expect = require('chai').expect;
+var request = require('supertest');
+
+var app = require('../../server');
+var logger = require('../../lib/logger');
+
+describe('robots.txt', function() {
+
+    var originalError;
+    var errorCalls;
+
+    beforeEach(function() {
+        errorCalls = [];
+        originalError = logger.error;
+        logger.error = function() {
+            errorCalls.push([].slice.call(arguments));
+        };
+    });
+
+    afterEach(function() {
+        logger.error = originalError;
+    });
+
+    it('should respond with a plain text robots policy without logging errors', function(done) {
+        request(app)
+            .get('/robots.txt')
+            .expect('Content-Type', /text\/plain/)
+            .expect(200)
+            .expect('User-agent: *\nDisallow:')
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+
+                try {
+                    expect(errorCalls.length).to.equal(0, 'Expected no error logs');
+                    done();
+                } catch (assertionError) {
+                    done(assertionError);
+                }
+            });
+    });
+
+});


### PR DESCRIPTION
## Summary
- register a dedicated /robots.txt handler that returns a simple plain-text policy
- add an integration test that ensures the robots response is successful and does not trigger error logging

## Testing
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68db7afd8bbc8323a695426e0bab6b50