### PR TITLE
Handle client errors without error-level logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,7 +35,17 @@ if (require.main === module) {
 module.exports = app;
 
 function handleError(error, req, res, next) {
-    logger.error('error handler received error: ' + error.message);
+    var statusCode = (error && typeof error.statusCode === 'number') ? error.statusCode : 500;
+    var errorMessage = error && error.message ? error.message : 'Internal Server Error';
+    var logMessage = 'error handler received error: ' + errorMessage;
 
-    res.status(error.statusCode || 500).json({error: error.message});
+    if (!error || statusCode >= 500 || statusCode < 400) {
+        logger.error(logMessage);
+    } else if (statusCode === 404 || statusCode === 405) {
+        logger.info(logMessage);
+    } else {
+        logger.warn(logMessage);
+    }
+
+    res.status(statusCode).json({error: errorMessage});
 }

--- a/tests/unit/serverErrorHandling.tests.js
+++ b/tests/unit/serverErrorHandling.tests.js
@@ -1,0 +1,50 @@
+var expect = require('chai').expect;
+var request = require('supertest');
+
+var logger = require('../../lib/logger');
+var app = require('../../server');
+
+describe('server error handling logging', function() {
+    var originalError;
+    var errorCalls;
+
+    beforeEach(function() {
+        originalError = logger.error;
+        errorCalls = 0;
+        logger.error = function() {
+            errorCalls++;
+        };
+    });
+
+    afterEach(function() {
+        logger.error = originalError;
+    });
+
+    it('does not log error level messages for 404 responses', function(done) {
+        request(app)
+            .get('/non-existent-route')
+            .expect(404)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+
+                expect(errorCalls).to.equal(0);
+                done();
+            });
+    });
+
+    it('does not log error level messages for 405 responses', function(done) {
+        request(app)
+            .get('/UpdateLocation')
+            .expect(405)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+
+                expect(errorCalls).to.equal(0);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
## Summary
- update the server error handler to log 404/405 responses at info level and reserve error logging for unexpected failures
- make the handler resilient to missing status codes and continue returning JSON errors
- add unit coverage to confirm 404/405 requests do not trigger error-level logs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db7afd8dd8832382712687300f8dcc